### PR TITLE
Fix throw/crash when using the tmpl_path constructor.

### DIFF
--- a/src/template.cpp
+++ b/src/template.cpp
@@ -31,6 +31,7 @@ template_t::template_t()
 template_t::template_t(std::string& tmpl_path)
 {
     template_path = tmpl_path;
+    template_t::compile_data();
 }
 
 /**


### PR DESCRIPTION
Using a template_t constructed with a tmpl_path would throw/crash in
render() due to uninitialized member "section".
