### PR TITLE
Fixed constructor with path argument.

### DIFF
--- a/src/template.cpp
+++ b/src/template.cpp
@@ -31,6 +31,7 @@ template_t::template_t()
 template_t::template_t(std::string& tmpl_path)
 {
     template_path = tmpl_path;
+    template_t::compile_data();
 }
 
 /**


### PR DESCRIPTION
That constructor was missing essential setup.
