### PR TITLE
Accept const string ref in template constructor

### DIFF
--- a/include/plustache/template.hpp
+++ b/include/plustache/template.hpp
@@ -20,7 +20,7 @@ namespace Plustache {
       typedef PlustacheTypes::CollectionType CollectionType;
     public:
         template_t ();
-        template_t (std::string& tmpl_path);
+        template_t (const std::string& tmpl_path);
         ~template_t ();
         std::string render(const std::string& tmplate, const Context& ctx);
         std::string render(const std::string& tmplate, const ObjectType& ctx);

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -30,7 +30,7 @@ template_t::template_t()
  *
  * @param tmpl_path path to the template directory
  */
-template_t::template_t(std::string& tmpl_path)
+template_t::template_t(const std::string& tmpl_path)
 {
     template_path = tmpl_path;
     template_t::compile_data();


### PR DESCRIPTION
I can see no need for the string to be non-const reference.