### PR TITLE
suppress handling of special characters in replacement text

### DIFF
--- a/src/template.cpp
+++ b/src/template.cpp
@@ -104,17 +104,7 @@ std::string template_t::render_tags(const std::string& tmplate,
         {
             try
             {
-                // get value
-                std::string s = ctx.get(key)[0][key];
-                // escape backslash in std::string
-                const std::string f = "\\";
-                size_t found = s.find(f);
-                while(found != std::string::npos)
-                {
-                    s.replace(found,f.length(),"\\\\");
-                    found = s.find(f, found+2);
-                }
-                repl.assign(s);
+                repl.assign(ctx.get(key)[0][key]);
             }
             catch(int i) { repl.assign(""); }
         }
@@ -140,8 +130,8 @@ std::string template_t::render_tags(const std::string& tmplate,
         }
 
         // replace
-        ret += regex_replace(text, tag, repl,
-                             boost::match_default | boost::format_all);
+        ret += boost::regex_replace(text, tag, repl,
+                             boost::match_default | boost::format_all | boost::regex_constants::format_literal);
         // change delimiter after was removed
         if (modifier == "=")
         {
@@ -250,7 +240,7 @@ std::string template_t::render_sections(const std::string& tmplate,
         }
         else repl.assign("");
         ret += boost::regex_replace(text, section, repl,
-                                    boost::match_default | boost::format_all);
+                                    boost::match_default | boost::format_all | boost::regex_constants::format_literal);
         rest.assign(matches[0].second, end);
         start = matches[0].second;
     }
@@ -335,7 +325,7 @@ std::string template_t::html_escape(const std::string& s)
         std::string repl;
         repl = escape_lut[key];
         ret += boost::regex_replace(text, escape_chars, repl,
-                                    boost::match_default | boost::format_all);
+                                    boost::match_default | boost::format_all | boost::regex_constants::format_literal);
         rest.assign(matches[0].second, end);
         start = matches[0].second;
     }

--- a/tests/test_simple_plustache.cpp
+++ b/tests/test_simple_plustache.cpp
@@ -15,6 +15,8 @@ class SimpleTest : public ::testing::Test
     std::string template_string;
     std::string result_notfound;
     std::string notfound;
+    std::string result_dollars;
+    std::string dollars;
     std::map<std::string, std::string> ctx;
     std::string file;
 
@@ -30,6 +32,7 @@ class SimpleTest : public ::testing::Test
     {
         template_string = "text {{title}} text";
         notfound = "text {{fitle}} text";
+        dollars = "text {{dollars}}";
         file = "multiple.mustache";
 
         std::ofstream myfile;
@@ -38,10 +41,13 @@ class SimpleTest : public ::testing::Test
         myfile.close();
 
         ctx["title"] = "replaced";
+        ctx["dollars"] = "$0";
+
         Plustache::template_t t;
         result_string = t.render(template_string, ctx);
         result_file = t.render(file, ctx);
         result_notfound = t.render(notfound, ctx);
+        result_dollars = t.render(dollars, ctx);
     }
 
     virtual void TearDown()
@@ -67,4 +73,10 @@ TEST_F(SimpleTest, TestSimpleNotFoundMustacheFromString)
 {
     const std::string expected = "text  text";
     EXPECT_EQ(expected, result_notfound);
+}
+
+TEST_F(SimpleTest, TestDollarSignsInValue)
+{
+    const std::string expected = "text $0";
+    EXPECT_EQ(expected, result_dollars);
 }

--- a/tests/test_simple_plustache.cpp
+++ b/tests/test_simple_plustache.cpp
@@ -17,6 +17,8 @@ class SimpleTest : public ::testing::Test
     std::string notfound;
     std::string result_dollars;
     std::string dollars;
+    std::string result_parens;
+    std::string parens;
     std::map<std::string, std::string> ctx;
     std::string file;
 
@@ -33,6 +35,7 @@ class SimpleTest : public ::testing::Test
         template_string = "text {{title}} text";
         notfound = "text {{fitle}} text";
         dollars = "text {{dollars}}";
+        parens = "text {{ open_paren }}inside{{ close_paren }}";
         file = "multiple.mustache";
 
         std::ofstream myfile;
@@ -42,12 +45,15 @@ class SimpleTest : public ::testing::Test
 
         ctx["title"] = "replaced";
         ctx["dollars"] = "$0";
+        ctx["open_paren"] = "(";
+        ctx["close_paren"] = ")";
 
         Plustache::template_t t;
         result_string = t.render(template_string, ctx);
         result_file = t.render(file, ctx);
         result_notfound = t.render(notfound, ctx);
         result_dollars = t.render(dollars, ctx);
+        result_parens = t.render(parens, ctx);
     }
 
     virtual void TearDown()
@@ -79,4 +85,10 @@ TEST_F(SimpleTest, TestDollarSignsInValue)
 {
     const std::string expected = "text $0";
     EXPECT_EQ(expected, result_dollars);
+}
+
+TEST_F(SimpleTest, TestParensInValue)
+{
+    const std::string expected = "text (inside)";
+    EXPECT_EQ(expected, result_parens);
 }


### PR DESCRIPTION
Given replacement text with special characters like `$`, `(`, `)`, `\`, and probably others, the call to `regex_replace` was handling these - lines 107-117 seem to be a workaround for `\`, but using the `boost::regex_constants::format_literal` to suppress handling of all special characters in the replacement text seems like a better solution.

See also #17 and boost [replace options](http://www.boost.org/doc/libs/1_55_0/doc/html/xpressive/user_s_guide.html#boost_xpressive.user_s_guide.string_substitutions.replace_options) documentation.